### PR TITLE
[docs] Update documentation for features from 2026-04-13

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Clear the noise. Exhale. Then just run it.
 - **Permission Approval Toggle** — Settings → Features → *Auto-approve Permissions*. When enabled (default), all tool permission requests are auto-approved; when disabled, an inline **Allow / Deny** prompt appears in the terminal for file writes, shell commands, and MCP calls. A yellow **auto-approve** status indicator in the status bar shows the current state.
 - **Ambient Music** — Settings → Experimental → *Ambient Music*. Plays a seamless looping background track at low volume during demos (starts on first user interaction to satisfy browser autoplay policy). Persisted to `localStorage`.
 - **Accessibility** — Comprehensive ARIA role attributes (toolbar, tablist, tab, tabpanel, listbox, option, textbox, status) and `:focus-visible` styles throughout the UI for screen reader support and Playwright `getByRole` compatibility.
-- **Clickable Version Badge** — Click the version number in the bottom-right corner to open `CHANGELOG.md` in a tab.
+- **Clickable Version Badge** — When *Show Version* is enabled in Settings, the version number appears in the bottom-right corner; clicking it opens `CHANGELOG.md` in a tab.
 - **Settings Panel** — Configure appearance (including Aurora Borealis background theme), permission behavior, feature flags, and experimental options from ⚙️ Settings
 
 ## Keyboard Shortcuts

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ Clear the noise. Exhale. Then just run it.
 - **Per-project Discovery** — Automatically discovers agents, skills, and MCP servers from project-local configs
 - **Copy & Paste** — Select and copy response text, paste into prompts
 - **Permission Approval Toggle** — Settings → Features → *Auto-approve Permissions*. When enabled (default), all tool permission requests are auto-approved; when disabled, an inline **Allow / Deny** prompt appears in the terminal for file writes, shell commands, and MCP calls. A yellow **auto-approve** status indicator in the status bar shows the current state.
+- **Ambient Music** — Settings → Experimental → *Ambient Music*. Plays a seamless looping background track at low volume during demos (starts on first user interaction to satisfy browser autoplay policy). Persisted to `localStorage`.
+- **Accessibility** — Comprehensive ARIA role attributes (toolbar, tablist, tab, tabpanel, listbox, option, textbox, status) and `:focus-visible` styles throughout the UI for screen reader support and Playwright `getByRole` compatibility.
+- **Clickable Version Badge** — Click the version number in the bottom-right corner to open `CHANGELOG.md` in a tab.
 - **Settings Panel** — Configure appearance (including Aurora Borealis background theme), permission behavior, feature flags, and experimental options from ⚙️ Settings
 
 ## Keyboard Shortcuts
@@ -239,6 +242,8 @@ npm run record:demo intro # Automated headless recording
 - [x] Custom themes (Aurora Borealis)
 - [x] Capabilities panel
 - [x] Per-project discovery
+- [x] Ambient music for demos
+- [x] ARIA accessibility (screen reader + Playwright getByRole support)
 - [ ] Export demos as standalone video files
 - [ ] Saved layout presets
 - [ ] Desktop app production builds (Windows, Linux)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -52,7 +52,7 @@ DemoGod is a web-based tool for creating interactive demo videos of GitHub Copil
 │  ┌──────────────────────────────────────────────────┐           │
 │  │  REST API (Express)                              │           │
 │  │  /api/browse  /api/file  /api/demos/:name        │           │
-│  │  /api/browse-files  /api/models                  │           │
+│  │  /api/browse-files  /api/models  /api/changelog  │           │
 │  └──────────────────────────────────────────────────┘           │
 └─────────────────────────────────────────────────────────────────┘
                           │
@@ -167,6 +167,7 @@ Additionally, the server includes a manual MCP tool discovery system (`queryMcpS
 | `GET /api/demos` | List available demo scripts | None (local only) |
 | `GET /api/demos/:name` | Load demo script JSON | Sanitized name (`[a-zA-Z0-9_-]`), path under `DEMOS_DIR` |
 | `GET /api/models` | List available Copilot models | None (local only) |
+| `GET /api/changelog` | Serve `CHANGELOG.md` content | None (local only) |
 
 #### WebSocket Handler
 
@@ -238,6 +239,7 @@ Class-based architecture. Major sections:
 
 - **Control bar** (top): project picker, mode toggle, popup toggle, file browser, new session, model/agent/skill pickers, 🔌 capabilities, record button, background color
 - **Terminal window**: macOS-style chrome with title bar, tab bar, output area, input line, status bar (shows git branch; shows yellow `auto-approve` text when auto-approve is enabled)
+- **Bottom-right controls**: version badge (`<a>` tag — click to view `CHANGELOG.md` in a tab via `GET /api/changelog`) and settings icon
 - **Overlay dialogs**: project picker, file browser, user input dialog, capability picker
 
 #### `styles.css` — Theming
@@ -512,6 +514,52 @@ Session containers use mode-colored subtle separator lines via the `--titlebar-b
 1. Add HTML toggle/dropdown in `#settings-window` in `index.html`
 2. Add a `dg-*` localStorage key
 3. Wire up event listener + init in the settings panel section of `app.js`
+
+## ARIA Accessibility
+
+DemoGod has comprehensive ARIA role attributes throughout its UI, enabling screen reader support and making it compatible with Playwright's `getByRole` locators for automated testing.
+
+### Role Map
+
+| Element | ARIA attributes | Notes |
+|---------|----------------|-------|
+| `#controls` | `role="toolbar"` + `aria-label` | Top control bar |
+| All control bar buttons | `aria-label` (deterministic names) | 16 buttons with getByRole-compatible names |
+| `.session-tab-bar` | `role="tablist"` | Session tab strip |
+| Dynamic session tabs | `role="tab"` + `aria-selected` | `aria-selected` managed by `switchTo()` |
+| Tab close buttons | `<button>` + `aria-label` | Changed from `<span>` for keyboard access |
+| `#tab-bar` | `role="tablist"` | Inner file/report tab bar |
+| Chat tab + dynamic tabs | `role="tab"` + `aria-selected` | Managed by `switchTab()` |
+| Tab panels | `role="tabpanel"` + `aria-label` | Chat, file view, report panels |
+| `.session-input` (contenteditable) | `role="textbox"` + `aria-label="Chat input"` | Chat prompt input |
+| `.status-text` | `role="status"` | Announces status changes to screen readers |
+| Picker lists | `role="listbox"` | `#picker-list`, `#filebrowser-list`, `#cappicker-list` |
+| Picker items | `role="option"` | Dynamic items in all pickers |
+| Dialog close dots | `role="button"` + `tabindex=0` + `aria-label` | All 7 traffic-light close controls |
+
+### Focus Visibility
+
+- Global `:focus-visible` rule: 2px solid accent outline for all focusable elements
+- Custom focus style for `.session-input`: bottom border glow using `--accent`
+
+## Playwright MCP Server
+
+DemoGod ships a `.mcp.json` in the project root that configures `@playwright/mcp` as a dev-time MCP server for Copilot. This gives Copilot live browser tools (navigate, screenshot, click, type, snapshot/accessibility tree) when working on demo specs.
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp", "--headless=false"],
+      "type": "local",
+      "tools": ["*"]
+    }
+  }
+}
+```
+
+The `--headless=false` flag opens a visible browser window so Copilot can inspect the live DemoGod UI rather than guessing selectors from documentation. This transforms Playwright spec generation from "guess and iterate" to "inspect, click, verify."
 
 ## Testing
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -237,9 +237,9 @@ Class-based architecture. Major sections:
 
 #### `index.html` — Structure
 
-- **Control bar** (top): project picker, mode toggle, popup toggle, file browser, new session, model/agent/skill pickers, 🔌 capabilities, record button, background color
+- **Control bar** (top): project picker, mode toggle, popup toggle, file browser, new session, model/agent/skill pickers, 🔌 capabilities, settings, background color
 - **Terminal window**: macOS-style chrome with title bar, tab bar, output area, input line, status bar (shows git branch; shows yellow `auto-approve` text when auto-approve is enabled)
-- **Bottom-right controls**: version badge (`<a>` tag — click to view `CHANGELOG.md` in a tab via `GET /api/changelog`) and settings icon
+- **Bottom-right controls**: version badge (`<a>` tag — click to view `CHANGELOG.md` in a tab via `GET /api/changelog`), reset-session button (`↻`), and record button
 - **Overlay dialogs**: project picker, file browser, user input dialog, capability picker
 
 #### `styles.css` — Theming

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -527,10 +527,10 @@ DemoGod has comprehensive ARIA role attributes throughout its UI, enabling scree
 | All control bar buttons | `aria-label` (deterministic names) | Deterministic `aria-label`s support `getByRole` locators |
 | `.session-tab-bar` | `role="tablist"` | Session tab strip |
 | Dynamic session tabs | `role="tab"` + `aria-selected` | `aria-selected` managed by `switchTo()` |
-| Tab close buttons | `<button>` + `aria-label` | Changed from `<span>` for keyboard access |
-| `#tab-bar` | `role="tablist"` | Inner file/report tab bar |
-| Chat tab + dynamic tabs | `role="tab"` + `aria-selected` | Managed by `switchTab()` |
-| Tab panels | `role="tabpanel"` + `aria-label` | Chat, file view, report panels |
+| File/report tab close buttons | `<button>` + `aria-label` | Inner tab close controls; changed from `<span>` for keyboard access |
+| `#tab-bar` | `role="tablist"` | Inner chat/file/report tab bar |
+| Chat tab + file/report tabs | `role="tab"` + `aria-selected` | Managed by `switchTab()`; excludes sub-agent tabs created separately in `app.js` |
+| Chat/file/report tab panels | `role="tabpanel"` + `aria-label` | Chat, file view, and report panels; excludes sub-agent panels |
 | `.session-input` (contenteditable) | `role="textbox"` + `aria-label="Chat input"` | Chat prompt input |
 | `.status-text` | `role="status"` | Announces status changes to screen readers |
 | Picker lists | `role="listbox"` | `#picker-list`, `#filebrowser-list`, `#cappicker-list` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -524,7 +524,7 @@ DemoGod has comprehensive ARIA role attributes throughout its UI, enabling scree
 | Element | ARIA attributes | Notes |
 |---------|----------------|-------|
 | `#controls` | `role="toolbar"` + `aria-label` | Top control bar |
-| All control bar buttons | `aria-label` (deterministic names) | 16 buttons with getByRole-compatible names |
+| All control bar buttons | `aria-label` (deterministic names) | Deterministic `aria-label`s support `getByRole` locators |
 | `.session-tab-bar` | `role="tablist"` | Session tab strip |
 | Dynamic session tabs | `role="tab"` + `aria-selected` | `aria-selected` managed by `switchTo()` |
 | Tab close buttons | `<button>` + `aria-label` | Changed from `<span>` for keyboard access |


### PR DESCRIPTION
## Documentation Updates - 2026-04-13

This PR updates the documentation based on features committed in the last 24 hours.

### Features Documented

- **Ambient Music toggle** — Settings → Experimental → *Ambient Music*; 90s looping track at 8% volume, browser autoplay-safe, `dg-ambient` localStorage key (from f765325 era / commit 63908289)
- **Comprehensive ARIA accessibility** — 52 ARIA role attributes across index.html, app.js, and styles.css (toolbar, tablist, tab, tabpanel, listbox, option, textbox, status); global `:focus-visible` styles (from commit f765325)
- **Playwright MCP server** — `@playwright/mcp` configured in `.mcp.json` with `--headless=false` for live browser inspection during spec generation (from commit 35dfa80e)
- **Clickable version badge** — version badge in bottom-right opens `CHANGELOG.md` in a tab via new `GET /api/changelog` endpoint (from commit 26ff79b2)

### Changes Made

- Updated `README.md`:
  - Added *Ambient Music* feature to the Features list
  - Added *Accessibility* feature entry documenting ARIA roles and `:focus-visible` styles
  - Added *Clickable Version Badge* feature entry
  - Added Ambient Music and ARIA Accessibility to the Roadmap as completed items

- Updated `docs/ARCHITECTURE.md`:
  - Added `GET /api/changelog` to the REST API table and system diagram
  - Updated `index.html` structure description to note the clickable version badge
  - Added new **ARIA Accessibility** section with full role map table and focus visibility rules
  - Added new **Playwright MCP Server** section documenting `.mcp.json` configuration and purpose

### Commits Referenced

- `f765325` — feat: comprehensive ARIA accessibility for Playwright agent compatibility
- `bc89bece` — feat: demo seed helpers + agent-assisted recording workflow docs *(RECORDING.md was updated by this commit directly; no further doc changes needed)*
- `35dfa80e` — feat: add Playwright MCP server for live browser inspection
- `26ff79b2` — feat: clickable version badge opens changelog in a tab
- `63908289` — feat: ambient music toggle in Settings → Experimental
- `34f900e1` — release: v0.2.0


<!-- gh-aw-tracker-id: daily-doc-updater -->




> Generated by [Daily Documentation Updater](https://github.com/suuus/demogod/actions/runs/24326274114/agentic_workflow) · ● 1.7M · [◷](https://github.com/search?q=repo%3Asuuus%2Fdemogod+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/github/gh-aw/blob/852cb06ad52958b402ed982b69957ffc57ca0619/.github/workflows/daily-doc-updater.md), run
> ```
> gh aw add github/gh-aw/.github/workflows/daily-doc-updater.md@852cb06ad52958b402ed982b69957ffc57ca0619
> ```
> - [x] expires <!-- gh-aw-expires: 2026-04-14T04:58:55.236Z --> on Apr 14, 2026, 4:58 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, gh-aw-tracker-id: daily-doc-updater, engine: copilot, model: auto, id: 24326274114, workflow_id: daily-doc-updater, run: https://github.com/suuus/demogod/actions/runs/24326274114 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->