### PR TITLE
[docs] Update documentation for features from 2026-04-14

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ Clear the noise. Exhale. Then just run it.
 - **Ambient Music** — Settings → Experimental → *Ambient Music*. Plays a seamless looping background track at low volume during demos (starts on first user interaction to satisfy browser autoplay policy). Persisted to `localStorage`.
 - **Accessibility** — Comprehensive ARIA role attributes (toolbar, tablist, tab, tabpanel, listbox, option, textbox, status) and `:focus-visible` styles throughout the UI for screen reader support and Playwright `getByRole` compatibility.
 - **Clickable Version Badge** — When *Show Version* is enabled in Settings, the version number appears in the bottom-right corner; clicking it opens `CHANGELOG.md` in a tab.
-- **Settings Panel** — Configure appearance (including Aurora Borealis background theme), permission behavior, feature flags, and experimental options from ⚙️ Settings
+- **Auto-open File Tabs** — Settings → Features → *Auto-open File Tabs* (on by default). Files created or edited by Copilot open as background tabs without stealing focus from the Chat tab. Disable to prevent any automatic tab opening. Persisted to `localStorage` as `dg-auto-file-tabs`.
+- **Context Setup Wizard** *(experimental)* — Settings → Experimental → *Context Wizard* enables the 🧭 Onboard button. The wizard guides engineers through setting up their AI development environment using a Copilot-driven `@context-wizard` agent that runs 7 phases: detect stack, discover MCP servers, locate docs, review config, install servers, generate Copilot instructions, and configure auth. Outputs `.mcp.json` and `.github/copilot-instructions.md`.
+- **Settings Panel** — Configure appearance (Aurora Borealis animated theme is the default), permission behavior, feature flags, and experimental options from ⚙️ Settings
 
 ## Keyboard Shortcuts
 
@@ -239,11 +241,14 @@ npm run record:demo intro # Automated headless recording
 - [x] Demo UI automation (layout, model, tile)
 - [x] Screen recording (MP4 + WebM)
 - [x] Copy & paste in session windows
-- [x] Custom themes (Aurora Borealis)
+- [x] Custom themes (Aurora Borealis — default)
 - [x] Capabilities panel
 - [x] Per-project discovery
 - [x] Ambient music for demos
 - [x] ARIA accessibility (screen reader + Playwright getByRole support)
+- [x] Integrated terminal as session tab
+- [x] Context Setup Wizard (enterprise onboarding)
+- [x] Auto-open file tabs (background, non-focus-stealing)
 - [ ] Export demos as standalone video files
 - [ ] Saved layout presets
 - [ ] Desktop app production builds (Windows, Linux)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -240,7 +240,7 @@ Class-based architecture. Major sections:
 
 #### `index.html` — Structure
 
-- **Control bar** (top): project picker, mode toggle, popup toggle, file browser, new session, model/agent/skill pickers, 🔌 capabilities, settings, background color
+- **Control bar** (top): project picker, mode toggle, popup toggle, file browser, new session, model/agent/skill pickers, 🔌 capabilities, 🧭 context wizard (experimental), background color, settings (last)
 - **Terminal window**: macOS-style chrome with title bar, tab bar, output area, input line, status bar (shows git branch; shows yellow `auto-approve` text when auto-approve is enabled)
 - **Bottom-right controls**: version badge (`<a>` tag — click to view `CHANGELOG.md` in a tab via `GET /api/changelog`), reset-session button (`↻`), and record button
 - **Overlay dialogs**: project picker, file browser, user input dialog, capability picker
@@ -537,6 +537,13 @@ Session containers use mode-colored subtle separator lines via the `--titlebar-b
 | `dg-context-wizard` | `"0"` / `"1"` | `"0"` | Context Setup Wizard button |
 | `dg-demo-studio` | `"0"` / `"1"` | `"0"` | Demo Studio button |
 
+### Feature Settings
+
+| localStorage Key | Type | Default | Description |
+|-----------------|------|---------|-------------|
+| `dg-auto-approve` | `"0"` / `"1"` | `"1"` | Auto-approve all Copilot permission requests |
+| `dg-auto-file-tabs` | `"0"` / `"1"` | `"1"` | Auto-open file tabs when Copilot creates/edits files |
+
 ## ARIA Accessibility
 
 DemoGod has comprehensive ARIA role attributes throughout its UI, enabling screen reader support and making it compatible with Playwright's `getByRole` locators for automated testing.
@@ -582,6 +589,47 @@ DemoGod ships a `.mcp.json` in the project root that configures `@playwright/mcp
 ```
 
 The `--headless=false` flag opens a visible browser window so Copilot can inspect the live DemoGod UI rather than guessing selectors from documentation. This transforms Playwright spec generation from "guess and iterate" to "inspect, click, verify."
+
+## Context Setup Wizard
+
+The Context Setup Wizard is an enterprise onboarding feature (gated behind Settings → Experimental → *Context Wizard*) that guides engineers through configuring their AI-assisted development environment.
+
+### Architecture
+
+The wizard is powered by a `@context-wizard` agent (`.github/agents/context-wizard.md`) that orchestrates 7 phases, each backed by a dedicated skill:
+
+| Phase | Skill | What it does |
+|-------|-------|-------------|
+| 1 | `context-detect` | Scans the project to detect the dev stack, tools, and existing config |
+| 2 | `context-discover` | Finds relevant MCP servers from GitHub catalog, org catalog, and vendor docs |
+| 3 | `context-docs` | Identifies where team documentation and knowledge sources live |
+| 4 | `context-review` | Reviews discovered servers and presents a summary for approval |
+| 5 | `context-install` | Writes approved MCP server entries to `.mcp.json` |
+| 6 | `context-instructions` | Generates `.github/copilot-instructions.md` with enterprise context |
+| 7 | `context-configure` | Guides per-server auth setup and tests connections |
+
+### MCP Server Discovery Chain
+
+The `context-discover` skill searches for MCP servers via four sources in order:
+
+1. **GitHub/MCP official catalog** — `search_repositories` with `topic:mcp-server`
+2. **Organization catalog** — `{org}/.github/mcp-catalog.json`
+3. **Vendor documentation** — `web_search` + `web_fetch`
+4. **Community fallback** — GitHub search for MCP server repositories
+
+### UI
+
+- **🧭 Onboard button** — appears in the control bar when enabled via the experimental toggle
+- **Full-size wizard panel** — overlays the main UI with a progress sidebar showing the 7 steps
+- **Embedded session** — the wizard conversation runs as a `TerminalSession` inside the panel
+- **Phase markers** — HTML comments (`<!-- phase: N -->`) in assistant output are tracked by the sidebar to advance the progress indicator
+- **Auto-start** — Phase 1 (`context-detect`) runs automatically when the panel is opened
+
+### Outputs
+
+The wizard generates two files in the project:
+- `.mcp.json` — MCP server configurations for approved servers
+- `.github/copilot-instructions.md` — Enterprise context, tool references, and cross-tool workflows
 
 ## Testing
 


### PR DESCRIPTION
## Documentation Updates - 2026-04-14

This PR updates the documentation based on features committed in the last 24 hours (since PR #17 was merged on 2026-04-13).

### Features Documented

- **Context Setup Wizard** — enterprise onboarding wizard with `@context-wizard` agent, 7 phases/skills, MCP discovery chain, and wizard panel UI (from commits `28b9f024`, `3b5995f1`)
- **Auto-open File Tabs** — new Settings → Features flag (`dg-auto-file-tabs`) for non-focus-stealing background tab opening (from commit `bcd91e84`)
- **Terminal as session tab** — tab mode for the integrated terminal already in ARCHITECTURE.md (from commit `6a64709855`); roadmap updated to reflect completion
- **Aurora Borealis as default theme** — updated README to note this is now the default background (from commit `6a64709855`)
- **Windows path separator fix** — `isUnderHome` now uses `path.sep` for cross-platform compatibility (from commit `8c9e56c9`)

### Changes Made

- Updated `README.md`:
  - Added *Context Setup Wizard* to Features list with 7-phase description
  - Added *Auto-open File Tabs* to Features list
  - Updated Aurora Borealis mention to note it's now the default theme
  - Added Context Setup Wizard, Terminal tab mode, and Auto-open File Tabs to Roadmap as completed items

- Updated `docs/ARCHITECTURE.md`:
  - Added new **Context Setup Wizard** section with phase table, MCP server discovery chain, UI description, and outputs
  - Added **Feature Settings** table with `dg-auto-approve` and `dg-auto-file-tabs`
  - Updated control bar description to include 🧭 Context Wizard button and Settings moved to last position

### Commits Referenced

- `28b9f024` — feat: Context Setup Wizard — agent, 7 skills, panel UI
- `3b5995f1` — feat: gate Context Wizard behind experimental toggle
- `6a64709855` — feat: terminal as session tab + aurora default theme
- `bcd91e84` — feat: auto-opened file tabs no longer steal focus + feature flag
- `8c9e56c9` — fix: isUnderHome uses path.sep for Windows compatibility
- `898db4e6` — chore: docs, tests, and dead code cleanup (ARCHITECTURE.md already updated by this commit)


<!-- gh-aw-tracker-id: daily-doc-updater -->




> Generated by [Daily Documentation Updater](https://github.com/suuus/demogod/actions/runs/24381510754/agentic_workflow) · ● 1.6M · [◷](https://github.com/search?q=repo%3Asuuus%2Fdemogod+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/github/gh-aw/blob/852cb06ad52958b402ed982b69957ffc57ca0619/.github/workflows/daily-doc-updater.md), run
> ```
> gh aw add github/gh-aw/.github/workflows/daily-doc-updater.md@852cb06ad52958b402ed982b69957ffc57ca0619
> ```
> - [x] expires <!-- gh-aw-expires: 2026-04-15T04:55:58.260Z --> on Apr 15, 2026, 4:55 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, gh-aw-tracker-id: daily-doc-updater, engine: copilot, model: auto, id: 24381510754, workflow_id: daily-doc-updater, run: https://github.com/suuus/demogod/actions/runs/24381510754 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->