### PR TITLE
[docs] Update documentation for features from 2026-04-17

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,7 +113,7 @@ The bridge wraps the `@github/copilot-sdk` and translates SDK events into simple
    - All skills enabled (via `enableAllSkills()` after creation)
    - Infinite sessions mode
    - Auto-approve all permission requests
-   - Custom system instructions for `ask_user` behavior
+   - Custom system instructions for `ask_user` behavior: always include a freeform "Other (specify)" option, use multipicker for multi-select questions, and set a default value
 3. `sendPrompt(text)` — sends a user message (non-blocking via `session.send()`)
 4. `resolveUserInput(requestId, values)` — resolves pending user input/elicitation requests
 5. `abort()` / `stop()` — cancel current operation / tear down session
@@ -144,7 +144,7 @@ The bridge wraps the `@github/copilot-sdk` and translates SDK events into simple
 **Critical design decisions:**
 - Uses `session.send()` not `session.sendAndWait()` — sub-agent tasks can run indefinitely
 - `onPermissionRequest` is configurable at runtime via `bridge.autoApprove` (toggled by `set_auto_approve` WS message). When `true` (default), all permission requests are auto-approved; when `false`, a `permission_request` event is emitted and the frontend shows an inline Allow/Deny prompt — see [Permission Requests](#permission-requests) below.
-- `systemMessage: { mode: "append" }` — adds `ask_user` instructions without replacing the default system prompt
+- `systemMessage: { mode: "append" }` — adds `ask_user` instructions (one question at a time; always include freeform "Other" + multipicker for multi-select; default value required) without replacing the default system prompt
 - `infiniteSessions: { enabled: true }` — session persists across long interactions
 
 ### 2. Server (`src/server.ts`)
@@ -600,9 +600,9 @@ The wizard is powered by a `@context-wizard` agent (`.github/agents/context-wiza
 
 | Phase | Skill | What it does |
 |-------|-------|-------------|
-| 1 | `context-detect` | Scans the project to detect the dev stack, tools, and existing config |
+| 1 | `context-detect` | Reads existing `.github/copilot-instructions.md` and `.vscode/` config first, then scans the project to detect the dev stack, CLI tools, and existing MCP/Copilot config |
 | 2 | `context-discover` | Finds relevant MCP servers from GitHub catalog, org catalog, and vendor docs |
-| 3 | `context-docs` | Identifies where team documentation and knowledge sources live |
+| 3 | `context-docs` | Identifies where team documentation and knowledge sources live across 6 categories: engineering docs, security policies, API specs, runbooks, ADRs, and product/business docs (PRD, BRD, BDD) |
 | 4 | `context-review` | Reviews discovered servers and presents a summary for approval |
 | 5 | `context-install` | Writes approved MCP server entries to `.mcp.json` |
 | 6 | `context-instructions` | Generates `.github/copilot-instructions.md` with enterprise context |


### PR DESCRIPTION
## Documentation Updates - 2026-04-17

This PR updates the documentation based on changes committed on 2026-04-16.

### Features Documented

- Improved `context-detect` skill — now reads existing Copilot config first, scans `.vscode/`, and reports CLI tools (from commit `cef7d7c`)
- Improved `context-docs` skill — added 6th category covering product/business documentation (PRD, BRD, BDD, Product strategy) (from commit `cef7d7c`)
- Improved `ask_user` system instructions in `CopilotBridge` — always includes freeform "Other (specify)" option, uses multipicker for multi-select questions, and always sets a default value (from commit `cef7d7c`)

### Changes Made

- Updated `docs/ARCHITECTURE.md` Phase 1 (`context-detect`) description in the Context Setup Wizard table to reflect reading existing instructions and `.vscode/` config first
- Updated `docs/ARCHITECTURE.md` Phase 3 (`context-docs`) description to document all 6 knowledge-source categories including product/business docs
- Updated `docs/ARCHITECTURE.md` CopilotBridge `ask_user` system instructions bullet points to describe the freeform "Other" option, multipicker behavior, and default-value requirement

### Commits Referenced

- `cef7d7c` — chore: improve context-wizard skills and ask_user instructions


<!-- gh-aw-tracker-id: daily-doc-updater -->




> Generated by [Daily Documentation Updater](https://github.com/suuus/demogod/actions/runs/24548282007/agentic_workflow) · ● 809.3K · [◷](https://github.com/search?q=repo%3Asuuus%2Fdemogod+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/github/gh-aw/blob/852cb06ad52958b402ed982b69957ffc57ca0619/.github/workflows/daily-doc-updater.md), run
> ```
> gh aw add github/gh-aw/.github/workflows/daily-doc-updater.md@852cb06ad52958b402ed982b69957ffc57ca0619
> ```
> - [x] expires <!-- gh-aw-expires: 2026-04-18T04:55:16.746Z --> on Apr 18, 2026, 4:55 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, gh-aw-tracker-id: daily-doc-updater, engine: copilot, model: auto, id: 24548282007, workflow_id: daily-doc-updater, run: https://github.com/suuus/demogod/actions/runs/24548282007 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->