### PR TITLE
[docs] Update architecture docs for Context Wizard improvements from 2026-04-16

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -144,7 +144,7 @@ The bridge wraps the `@github/copilot-sdk` and translates SDK events into simple
 **Critical design decisions:**
 - Uses `session.send()` not `session.sendAndWait()` — sub-agent tasks can run indefinitely
 - `onPermissionRequest` is configurable at runtime via `bridge.autoApprove` (toggled by `set_auto_approve` WS message). When `true` (default), all permission requests are auto-approved; when `false`, a `permission_request` event is emitted and the frontend shows an inline Allow/Deny prompt — see [Permission Requests](#permission-requests) below.
-- `systemMessage: { mode: "append" }` — adds `ask_user` instructions without replacing the default system prompt
+- `systemMessage: { mode: "append" }` — adds `ask_user` instructions without replacing the default system prompt. The appended instructions require: (1) always use `ask_user` for any input or decision — never ask in plain text, (2) one question per call, (3) sub-agents must follow the same rules, (4) prefer enum/boolean fields over free-text, always include an `"other:"` freeform textbox, use a multipicker when multiple selections are valid, and always set a default value
 - `infiniteSessions: { enabled: true }` — session persists across long interactions
 
 ### 2. Server (`src/server.ts`)
@@ -600,9 +600,9 @@ The wizard is powered by a `@context-wizard` agent (`.github/agents/context-wiza
 
 | Phase | Skill | What it does |
 |-------|-------|-------------|
-| 1 | `context-detect` | Scans the project to detect the dev stack, tools, and existing config |
+| 1 | `context-detect` | Reads existing `copilot-instructions.md` first, then scans the project for dev stack, languages, CI/CD, cloud indicators, `.vscode/` config, CLI tools, and already-configured MCP servers |
 | 2 | `context-discover` | Finds relevant MCP servers from GitHub catalog, org catalog, and vendor docs |
-| 3 | `context-docs` | Identifies where team documentation and knowledge sources live |
+| 3 | `context-docs` | Identifies where team documentation and knowledge sources live — asks about engineering docs, security policies, API specs, runbooks, ADRs, and product documentation (PRDs, BRDs) |
 | 4 | `context-review` | Reviews discovered servers and presents a summary for approval |
 | 5 | `context-install` | Writes approved MCP server entries to `.mcp.json` |
 | 6 | `context-instructions` | Generates `.github/copilot-instructions.md` with enterprise context |


### PR DESCRIPTION
## Documentation Updates - 2026-04-18

This PR updates `docs/ARCHITECTURE.md` based on changes merged on 2026-04-16.

### Features Documented

- Improved `context-detect` skill (Phase 1 of Context Setup Wizard)
- Improved `context-docs` skill (Phase 3 of Context Setup Wizard)
- Refined `ask_user` system instruction behavior in `CopilotBridge`

### Changes Made

- **Updated Phase 1 (`context-detect`) description** — now reflects that it reads existing `copilot-instructions.md` first before scanning, also scans `.vscode/`, and reports CLI tools and already-configured MCP servers
- **Updated Phase 3 (`context-docs`) description** — now reflects that it covers 6 documentation categories including the newly added **product documentation** category (PRDs, BRDs, BDD, product strategy — sourced from SharePoint/OneDrive, Google Docs, Confluence, repo `/docs`, or Other)
- **Expanded `ask_user` system instruction description** — documents all four rules injected into the session system prompt: use `ask_user` (never plain text), one question at a time, sub-agents follow the same rules, and always include an `"other:"` freeform option + multipicker for multi-select + default value

### Merged Commits Referenced

- `cef7d7c` — `chore: improve context-wizard skills and ask_user instructions`
  - `context-detect`: read existing instructions first, scan `.vscode/`, report CLI tools
  - `context-docs`: add product/business documentation question (6th category)
  - `copilot-bridge`: ask_user now suggests freeform `"other:"` option and multipicker


<!-- gh-aw-tracker-id: daily-doc-updater -->




> Generated by [Daily Documentation Updater](https://github.com/suuus/demogod/actions/runs/24597103837/agentic_workflow) · ● 578.7K · [◷](https://github.com/search?q=repo%3Asuuus%2Fdemogod+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/github/gh-aw/blob/852cb06ad52958b402ed982b69957ffc57ca0619/.github/workflows/daily-doc-updater.md), run
> ```
> gh aw add github/gh-aw/.github/workflows/daily-doc-updater.md@852cb06ad52958b402ed982b69957ffc57ca0619
> ```
> - [x] expires <!-- gh-aw-expires: 2026-04-19T04:46:13.914Z --> on Apr 19, 2026, 4:46 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, gh-aw-tracker-id: daily-doc-updater, engine: copilot, model: auto, id: 24597103837, workflow_id: daily-doc-updater, run: https://github.com/suuus/demogod/actions/runs/24597103837 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->